### PR TITLE
Handle 5xx errors from proxy server during CONNECT request

### DIFF
--- a/src/main/java/com/ning/http/client/providers/grizzly/AhcEventFilter.java
+++ b/src/main/java/com/ning/http/client/providers/grizzly/AhcEventFilter.java
@@ -182,8 +182,17 @@ final class AhcEventFilter extends HttpClientFilter {
         final HttpTransactionContext context =
                 HttpTransactionContext.currentTransaction(httpHeader);
         final int status = responsePacket.getStatus();
-        if (context.establishingTunnel && HttpStatus.OK_200.statusMatches(status)) {
-            return;
+        if (context.establishingTunnel) { 
+        	if (HttpStatus.OK_200.statusMatches(status)) {
+        		return;
+        	} else if (HttpStatus.INTERNAL_SERVER_ERROR_500.statusMatches(status)||
+        			HttpStatus.NOT_IMPLEMENTED_501.statusMatches(status)||
+        			HttpStatus.BAD_GATEWAY_502.statusMatches(status)||
+        			HttpStatus.SERVICE_UNAVAILABLE_503.statusMatches(status)||
+        			HttpStatus.GATEWAY_TIMEOUT_504.statusMatches(status)||
+        			HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505.statusMatches(status)) {
+        		context.abort(new IOException("Proxy server returned "+status+" status for CONNECT attempt."));
+        	}
         }
         if (HttpStatus.CONINTUE_100.statusMatches(status)) {
             ctx.notifyUpstream(new ContinueEvent(context));            


### PR DESCRIPTION
When a proxy server returns a 5xx family status code during a CONNECT attempt (to access an HTTPS URL) there is a NullPointerException in org.glassfish.grizzly.http.HttpClientFilter$ClientHttpResponseImpl.getProcessingState.  This results from a NumberFormatException that is thrown in org.glassfish.grizzly.http.HttpClientFilter.decodeInitialLineFromBytes, where it's expecting to see output from the tunneled connection, but instead it's finding the body of the error response.  It may be worth adding some additional checks for other status codes.