### PR TITLE
Raw Encoder doesn't prepend query params with '&'

### DIFF
--- a/src/main/java/com/ning/http/util/UriEncoder.java
+++ b/src/main/java/com/ning/http/util/UriEncoder.java
@@ -92,6 +92,7 @@ public enum UriEncoder {
             // concatenate raw query + raw query params
             StringBuilder sb = StringUtils.stringBuilder();
             sb.append(query);
+            b.append('&');
             appendRawQueryParams(sb, queryParams);
             sb.setLength(sb.length() - 1);
             return sb.toString();


### PR DESCRIPTION
The behavior between FIXED and RAW differs in that FIXED adds a `&` character before appending additional query parameters.